### PR TITLE
Force gunzip so that it doesn't ask questions

### DIFF
--- a/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
@@ -61,7 +61,7 @@ EOT
         $output->writeln('<info>Download completed</info>');
         $output->writeln('Unzip the downloading data');
         $output->writeln('...');
-        system('gunzip '.$destination);
+        system('gunzip -f '.$destination);
         $output->writeln('<info>Unzip completed</info>');
 
         return true;


### PR DESCRIPTION
I want to schedule the update of the MaxMind database via cron, but as the dat file already exists, the gunzip command hangs waiting for user input.  I have just added a -f switch to the gunzip command to silence this question.
