### PR TITLE
Fix for getter GetRegion throwing undefined index. Can be tested with ip...

### DIFF
--- a/src/Maxmind/Bundle/GeoipBundle/Service/GeoipManager.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Service/GeoipManager.php
@@ -78,13 +78,16 @@ class GeoipManager
         if ($ip)
             $this->lookup($ip);
 
-        if ($this->record)
+        if ($this->record
+                && $this->record->country_code
+                && $this->record->region
+        )
           return GeoIpRegionVars::$GEOIP_REGION_NAME
             [$this->record->country_code]
             [$this->record->region]
           ;
 
-        return $this->record;
+        return null;
     }
 
     public function getCity($ip = null)


### PR DESCRIPTION
There are some ips that after lookup produce no $this->record->region keys. For example(178.136.197.30)
