### PR TITLE
Quote destination path when executing gunzip

### DIFF
--- a/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
@@ -61,7 +61,7 @@ EOT
         $output->writeln('<info>Download completed</info>');
         $output->writeln('Unzip the downloading data');
         $output->writeln('...');
-        system('gunzip -f '.$destination);
+        system('gunzip -f "'.$destination.'"');
         $output->writeln('<info>Unzip completed</info>');
 
         return true;


### PR DESCRIPTION
Without quotes, gunzip command will fail if there are spaces in path (or other special characters).
