### PR TITLE
Fix exit codes returned by the command "maxmind:geoip:update-data".

### DIFF
--- a/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Command/LoadDataCommand.php
@@ -56,14 +56,13 @@ EOT
         if (!copy($source, $destination)) {
             $output->writeln('<error>Error during file download occured</error>');
 
-            return false;
+            return 1;
         }
+
         $output->writeln('<info>Download completed</info>');
         $output->writeln('Unzip the downloading data');
         $output->writeln('...');
         system('gunzip -f "'.$destination.'"');
         $output->writeln('<info>Unzip completed</info>');
-
-        return true;
     }
 }


### PR DESCRIPTION
The method "execute" must return an integer or null, not a boolean. 
Return "false" is equivalent to return a success code.