### PR TITLE
instantiate geoip class at first use

### DIFF
--- a/src/Maxmind/Bundle/GeoipBundle/Service/GeoipManager.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Service/GeoipManager.php
@@ -9,19 +9,28 @@ use Maxmind\lib\GeoIpRegionVars;
 
 class GeoipManager
 {
-    protected $geoip = null;
+    protected $geoip;
 
-    protected $record = null;
+    protected $filePath;
+
+    protected $record;
 
     public function __construct(Kernel $kernel)
     {
-    	$filePath = $kernel->getContainer()->getParameter('maxmind_geoip_data_file_path');
-        $this->geoip = new GeoIp($filePath);
+    	$this->filePath = $kernel->getContainer()->getParameter('maxmind_geoip_data_file_path');
+    }
+
+    protected function getGeoip()
+    {
+        if ($this->geoip instanceof GeoIp)
+            $this->geoip = new GeoIp($this->filePath);
+
+        return $this->geoip;
     }
 
     public function lookup($ip)
     {
-        $this->record = $this->geoip->geoip_record_by_addr($ip);
+        $this->record = $this->getGeoip()->geoip_record_by_addr($ip);
 
         if ($this->record)
             return $this;


### PR DESCRIPTION
I have the following issue with 1.0.1 release, which added a twig extension:

when `composer install` (or update) executed, there is a command 
which clears the cache (with `--no-warmup` param, but warmup will happen anyway to run the symfony command itself)
which warms up twig 
which instantiate `GeoipManager` service 
which instantiate `Geoip` 
which tries to open the data file 
which is not there for some reason (eg: because it is a fresh install, bundle is first installed)

This pull request also fix the performance issue caused by always opening data file whenever twig is used.