### PR TITLE
Workaround to fix function 'code' not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Now can use the Maxmind GeoIp Library everywhere in your Symfony2 application.
 Usage
 -----
 
-The following exemples are available if you are in a controller
+The following examples are available if you are in a controller
 
 ```php
 $geoip = $this->get('maxmind.geoip')->lookup(%IP_ADDR%);
@@ -99,8 +99,8 @@ Or in twig file
 {{ ip|geoip|continentCode }}
 ```
 
-You can add a demo route in your 'routing_dev' to get an exemple on how
-this bundle work for exemple:
+You can add a demo route in your 'routing_dev' to get an example on how
+this bundle work for example:
 
 ```yaml
 _maxmind_geoip:

--- a/src/Maxmind/Bundle/GeoipBundle/Resources/views/layout.html.twig
+++ b/src/Maxmind/Bundle/GeoipBundle/Resources/views/layout.html.twig
@@ -11,7 +11,7 @@
             {% endblock %}
         </div>
 
-        {% if code is defined %}
+        {% if code %}
             <h2>Code behind this page</h2>
             <div class="symfony-content">{{ code|raw }}</div>
         {% endif %}

--- a/src/Maxmind/Bundle/GeoipBundle/Twig/GeoipExtension.php
+++ b/src/Maxmind/Bundle/GeoipBundle/Twig/GeoipExtension.php
@@ -7,6 +7,7 @@
 namespace Maxmind\Bundle\GeoipBundle\Twig;
 
 use Maxmind\Bundle\GeoipBundle\Service\GeoipManager;
+use Twig_Environment;
 
 /**
  * Class GeoipExtension
@@ -38,6 +39,20 @@ class GeoipExtension extends \Twig_Extension
         );
     }
 
+    public function getFunctions()
+    {
+        return array(
+            new \Twig_SimpleFunction(
+                'code',
+                array($this, 'getCode'),
+                array(
+                    'is_safe' => array('html'),
+                    'needs_environment' => true
+                )
+            ),
+        );
+    }
+
     /**
      * @param string $ip
      *
@@ -46,6 +61,25 @@ class GeoipExtension extends \Twig_Extension
     public function geoipFilter($ip)
     {
         return $this->geoipManager->lookup($ip);
+    }
+
+    /**
+     * @param Twig_Environment $env
+     * @param $template
+     * @return bool|mixed
+     * @throws \Twig_Error_Runtime
+     */
+    public function getCode(Twig_Environment $env, $template)
+    {
+        if ($env->hasExtension('demo')) {
+            $functions = $env->getExtension('demo')->getFunctions();
+            foreach ($functions as $function) {
+                if ($function->getName() === 'code') {
+                    return call_user_func($function->getCallable(), $template);
+                }
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Demo page is not working if you don't have AcmeDemoBundle installed. Function 'code' is defined in DemoBundle twig extension.

> The template "MaxmindGeoipBundle:Demo:index.html.twig" contains an error: Unknown "code" function in "MaxmindGeoipBundle:Demo:index.html.twig" at line 56.

And in addition to it I receive error message log when I do cache:clear command. Even without adding DemoController to my routing yaml file.